### PR TITLE
Capture and pass along connection error to JoinGameScreen

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="no.strooped" >
     <uses-permission android:name="android.permission.INTERNET" />
     <application
@@ -12,8 +13,9 @@
         <activity
             android:name="no.strooped.AndroidLauncher"
             android:label="@string/app_name"
-            android:screenOrientation="fullSensor"
-            android:configChanges="keyboard|keyboardHidden|navigation|orientation|screenSize|screenLayout">
+            android:screenOrientation="portrait"
+            android:configChanges="orientation|keyboardHidden"
+            tools:ignore="LockedOrientationActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/core/src/main/kotlin/no/strooped/StroopedController.kt
+++ b/core/src/main/kotlin/no/strooped/StroopedController.kt
@@ -19,6 +19,8 @@ class StroopedController : Game() {
     private var joinGameService: JoinGameService = JoinGameService(socket)
     private var gameLifecycleService: GameLifecycleService = GameLifecycleService(socket)
 
+    private val errorMessages: ArrayList<String> = ArrayList()
+
     override fun create() {
         openJoinScreen()
         gameLifecycleService.onNextTask {
@@ -44,8 +46,17 @@ class StroopedController : Game() {
 
     fun connectToGame(username: String, joinPin: String) {
         joinGameService.joinGame(username, joinPin) {
-            GameSingleton.room = it
-            changeScreen(LobbyScreen(this))
+            it.fold(
+                { gameRoom ->
+                    GameSingleton.room = gameRoom
+                    changeScreen(LobbyScreen(this))
+                },
+                { err ->
+                    println("Failed to join game!: ${err.message}")
+                    // Re-render JoinGameScreen with error message
+                    changeScreen(JoinGameScreen(this, err.localizedMessage))
+                }
+            )
         }
     }
     fun openJoinScreen() {

--- a/core/src/main/kotlin/no/strooped/StroopedController.kt
+++ b/core/src/main/kotlin/no/strooped/StroopedController.kt
@@ -10,7 +10,8 @@ import no.strooped.view.screen.EndRoundScreen
 import no.strooped.view.screen.JoinGameScreen
 import no.strooped.view.screen.LobbyScreen
 import no.strooped.view.screen.TaskScreen
-import no.strooped.view.screen.components.Answer
+import no.strooped.model.Answer
+import no.strooped.singleton.GameSingleton
 
 const val TITLE = "Strooped"
 
@@ -18,9 +19,6 @@ class StroopedController : Game() {
     private var socket: SocketService = SocketService()
     private var joinGameService: JoinGameService = JoinGameService(socket)
     private var gameLifecycleService: GameLifecycleService = GameLifecycleService(socket)
-
-    private val errorMessages: ArrayList<String> = ArrayList()
-
     override fun create() {
         openJoinScreen()
         gameLifecycleService.onNextTask {
@@ -52,8 +50,6 @@ class StroopedController : Game() {
                     changeScreen(LobbyScreen(this))
                 },
                 { err ->
-                    println("Failed to join game!: ${err.message}")
-                    // Re-render JoinGameScreen with error message
                     changeScreen(JoinGameScreen(this, err.localizedMessage))
                 }
             )

--- a/core/src/main/kotlin/no/strooped/StroopedController.kt
+++ b/core/src/main/kotlin/no/strooped/StroopedController.kt
@@ -2,16 +2,16 @@ package no.strooped
 
 import com.badlogic.gdx.Game
 import com.badlogic.gdx.Screen
+import no.strooped.model.Answer
 import no.strooped.service.GameLifecycleService
 import no.strooped.service.JoinGameService
 import no.strooped.service.SocketService
+import no.strooped.singleton.GameSingleton
 import no.strooped.view.screen.EndGameScreen
 import no.strooped.view.screen.EndRoundScreen
 import no.strooped.view.screen.JoinGameScreen
 import no.strooped.view.screen.LobbyScreen
 import no.strooped.view.screen.TaskScreen
-import no.strooped.model.Answer
-import no.strooped.singleton.GameSingleton
 
 const val TITLE = "Strooped"
 

--- a/core/src/main/kotlin/no/strooped/controller/AbstractController.kt
+++ b/core/src/main/kotlin/no/strooped/controller/AbstractController.kt
@@ -1,3 +1,0 @@
-package no.strooped.controller
-
-abstract class AbstractController

--- a/core/src/main/kotlin/no/strooped/model/Answer.kt
+++ b/core/src/main/kotlin/no/strooped/model/Answer.kt
@@ -1,4 +1,4 @@
-package no.strooped.view.screen.components
+package no.strooped.model
 
 import org.json.JSONObject
 

--- a/core/src/main/kotlin/no/strooped/model/ColorOption.kt
+++ b/core/src/main/kotlin/no/strooped/model/ColorOption.kt
@@ -1,3 +1,3 @@
-package no.strooped.view.screen.components
+package no.strooped.model
 
 data class ColorOption(val color: String, val name: String, val backgroundColor: String, val fontColor: String)

--- a/core/src/main/kotlin/no/strooped/model/GameRoom.kt
+++ b/core/src/main/kotlin/no/strooped/model/GameRoom.kt
@@ -1,3 +1,3 @@
 package no.strooped.model
 
-class GameRoom(val player: Player, val gamePin: String, var currentTask: Task? = null)
+data class GameRoom(val player: Player, val gamePin: String, var currentTask: Task? = null)

--- a/core/src/main/kotlin/no/strooped/model/Task.kt
+++ b/core/src/main/kotlin/no/strooped/model/Task.kt
@@ -1,5 +1,3 @@
 package no.strooped.model
 
-import no.strooped.view.screen.components.ColorOption
-
 data class Task(val buttons: List<ColorOption>)

--- a/core/src/main/kotlin/no/strooped/service/GameLifecycleService.kt
+++ b/core/src/main/kotlin/no/strooped/service/GameLifecycleService.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.strooped.model.Task
-import no.strooped.view.screen.components.Answer
+import no.strooped.model.Answer
 
 typealias TaskStartCallback = (Task) -> Unit
 typealias RoundEndCallback = (Int) -> Unit

--- a/core/src/main/kotlin/no/strooped/service/GameLifecycleService.kt
+++ b/core/src/main/kotlin/no/strooped/service/GameLifecycleService.kt
@@ -3,8 +3,8 @@ package no.strooped.service
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import no.strooped.model.Task
 import no.strooped.model.Answer
+import no.strooped.model.Task
 
 typealias TaskStartCallback = (Task) -> Unit
 typealias RoundEndCallback = (Int) -> Unit

--- a/core/src/main/kotlin/no/strooped/service/JoinGameService.kt
+++ b/core/src/main/kotlin/no/strooped/service/JoinGameService.kt
@@ -7,9 +7,9 @@ class JoinGameService(
     private val socket: SocketService
 ) {
 
-    fun joinGame(username: String, joinPin: String, callback: (GameRoom) -> Unit) {
+    fun joinGame(username: String, joinPin: String, callback: (Result<GameRoom>) -> Unit) {
         socket.onConnect {
-            callback(GameRoom(Player(username), joinPin))
+            callback(it.map { GameRoom(Player(username), joinPin) })
         }
         socket.connect(joinPin, username)
     }

--- a/core/src/main/kotlin/no/strooped/service/SocketService.kt
+++ b/core/src/main/kotlin/no/strooped/service/SocketService.kt
@@ -29,7 +29,12 @@ class SocketService {
             val errorMessage = it[0].toString().trim()
             println("Failed to connect to socket: $errorMessage")
             Gdx.app.postRunnable {
-                listener?.invoke(runCatching { throw RuntimeException("Could not connect to socket: $errorMessage") })
+                listener?.invoke(runCatching {
+                    when (errorMessage) {
+                        "Invalid joinToken" -> throw RuntimeException("Please enter a valid game PIN!")
+                        else -> throw RuntimeException("Could not connect to socket: $errorMessage")
+                    }
+                })
             }
         }
         listeners.forEach { (type, callback) ->

--- a/core/src/main/kotlin/no/strooped/service/SocketService.kt
+++ b/core/src/main/kotlin/no/strooped/service/SocketService.kt
@@ -19,13 +19,15 @@ class SocketService {
         socketInstance = socket
         socket.on(Socket.EVENT_CONNECT) {
             Gdx.app.postRunnable {
+                // Socket is wrapped inside runCatching
+                // to ensure callback receives the data as Result<Socket>
+                // and not just Socket
                 listener?.invoke(runCatching { socket })
             }
         }
         socket.on(Socket.EVENT_ERROR) {
             val errorMessage = it[0].toString().trim()
-            println("Im failing")
-            println(errorMessage)
+            println("Failed to connect to socket: $errorMessage")
             Gdx.app.postRunnable {
                 listener?.invoke(runCatching { throw RuntimeException("Could not connect to socket: $errorMessage") })
             }

--- a/core/src/main/kotlin/no/strooped/service/SocketService.kt
+++ b/core/src/main/kotlin/no/strooped/service/SocketService.kt
@@ -19,7 +19,7 @@ class SocketService {
         socketInstance = socket
         socket.on(Socket.EVENT_CONNECT) {
             Gdx.app.postRunnable {
-                listener?.invoke(kotlin.runCatching { socket })
+                listener?.invoke(runCatching { socket })
             }
         }
         socket.on(Socket.EVENT_ERROR) {

--- a/core/src/main/kotlin/no/strooped/singleton/GameSingleton.kt
+++ b/core/src/main/kotlin/no/strooped/singleton/GameSingleton.kt
@@ -1,4 +1,4 @@
-package no.strooped
+package no.strooped.singleton
 
 import no.strooped.model.GameRoom
 

--- a/core/src/main/kotlin/no/strooped/singleton/TextureSizes.kt
+++ b/core/src/main/kotlin/no/strooped/singleton/TextureSizes.kt
@@ -1,4 +1,4 @@
-package no.strooped
+package no.strooped.singleton
 
 import com.badlogic.gdx.Gdx
 import no.strooped.util.Size

--- a/core/src/main/kotlin/no/strooped/view/components/Animation.kt
+++ b/core/src/main/kotlin/no/strooped/view/components/Animation.kt
@@ -1,4 +1,4 @@
-package no.strooped.view.screen.components
+package no.strooped.view.components
 
 import com.badlogic.gdx.graphics.Texture
 

--- a/core/src/main/kotlin/no/strooped/view/components/Button.kt
+++ b/core/src/main/kotlin/no/strooped/view/components/Button.kt
@@ -1,4 +1,4 @@
-package no.strooped.view.screen.components
+package no.strooped.view.components
 
 import com.badlogic.gdx.scenes.scene2d.InputEvent
 import com.badlogic.gdx.scenes.scene2d.InputListener

--- a/core/src/main/kotlin/no/strooped/view/components/ColorButton.kt
+++ b/core/src/main/kotlin/no/strooped/view/components/ColorButton.kt
@@ -1,4 +1,4 @@
-package no.strooped.view.screen.components
+package no.strooped.view.components
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
@@ -8,7 +8,8 @@ import com.badlogic.gdx.graphics.g2d.BitmapFont
 import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
-import no.strooped.TextureSizes
+import no.strooped.singleton.TextureSizes
+import no.strooped.model.ColorOption
 import no.strooped.util.Size
 private val FONT_SIZE = TextureSizes.getScaledFontSize(1.5f)
 

--- a/core/src/main/kotlin/no/strooped/view/components/ColorButton.kt
+++ b/core/src/main/kotlin/no/strooped/view/components/ColorButton.kt
@@ -8,8 +8,8 @@ import com.badlogic.gdx.graphics.g2d.BitmapFont
 import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
-import no.strooped.singleton.TextureSizes
 import no.strooped.model.ColorOption
+import no.strooped.singleton.TextureSizes
 import no.strooped.util.Size
 private val FONT_SIZE = TextureSizes.getScaledFontSize(1.5f)
 

--- a/core/src/main/kotlin/no/strooped/view/components/Label.kt
+++ b/core/src/main/kotlin/no/strooped/view/components/Label.kt
@@ -1,10 +1,11 @@
-package no.strooped.view.screen.components
+package no.strooped.view.components
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.g2d.BitmapFont
 import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.ui.Label
+import no.strooped.singleton.TextureSizes
 
 class Label(
     message: String,
@@ -19,5 +20,8 @@ class Label(
         setFontScale(font)
         setWrap(true) // fit inside the label
         setAlignment(1) // center the text
+    }
+    fun changeFontSize(font: Float) {
+        style.font.data.setScale(TextureSizes.getScaledFontSize(font))
     }
 }

--- a/core/src/main/kotlin/no/strooped/view/components/PlacementLabel.kt
+++ b/core/src/main/kotlin/no/strooped/view/components/PlacementLabel.kt
@@ -1,4 +1,4 @@
-package no.strooped.view.screen.components
+package no.strooped.view.components
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color

--- a/core/src/main/kotlin/no/strooped/view/components/TextFieldInput.kt
+++ b/core/src/main/kotlin/no/strooped/view/components/TextFieldInput.kt
@@ -1,4 +1,4 @@
-package no.strooped.view.screen.components
+package no.strooped.view.components
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
@@ -9,7 +9,7 @@ import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.Skin
 import com.badlogic.gdx.scenes.scene2d.ui.TextField
-import no.strooped.TextureSizes
+import no.strooped.singleton.TextureSizes
 import no.strooped.util.Size
 
 private fun buildTextFieldStyle(): TextField.TextFieldStyle {

--- a/core/src/main/kotlin/no/strooped/view/components/UIButton.kt
+++ b/core/src/main/kotlin/no/strooped/view/components/UIButton.kt
@@ -1,4 +1,4 @@
-package no.strooped.view.screen.components
+package no.strooped.view.components
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Color
@@ -8,7 +8,7 @@ import com.badlogic.gdx.graphics.g2d.NinePatch
 import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.ui.Skin
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton
-import no.strooped.TextureSizes
+import no.strooped.singleton.TextureSizes
 import no.strooped.util.Size
 
 private fun buildStyle(): TextButton.TextButtonStyle {

--- a/core/src/main/kotlin/no/strooped/view/screen/EndGameScreen.kt
+++ b/core/src/main/kotlin/no/strooped/view/screen/EndGameScreen.kt
@@ -7,12 +7,12 @@ import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.utils.viewport.ScreenViewport
-import no.strooped.GameSingleton
+import no.strooped.singleton.GameSingleton
 import no.strooped.StroopedController
-import no.strooped.TextureSizes
-import no.strooped.view.screen.components.Label
-import no.strooped.view.screen.components.PlacementLabel
-import no.strooped.view.screen.components.UIButton
+import no.strooped.singleton.TextureSizes
+import no.strooped.view.components.Label
+import no.strooped.view.components.PlacementLabel
+import no.strooped.view.components.UIButton
 /**
  * Uses https://otter.tech/an-mvc-guide-for-libgdx/ as inspiration
  * */

--- a/core/src/main/kotlin/no/strooped/view/screen/EndGameScreen.kt
+++ b/core/src/main/kotlin/no/strooped/view/screen/EndGameScreen.kt
@@ -7,8 +7,8 @@ import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.utils.viewport.ScreenViewport
-import no.strooped.singleton.GameSingleton
 import no.strooped.StroopedController
+import no.strooped.singleton.GameSingleton
 import no.strooped.singleton.TextureSizes
 import no.strooped.view.components.Label
 import no.strooped.view.components.PlacementLabel

--- a/core/src/main/kotlin/no/strooped/view/screen/EndRoundScreen.kt
+++ b/core/src/main/kotlin/no/strooped/view/screen/EndRoundScreen.kt
@@ -7,12 +7,12 @@ import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.utils.viewport.ScreenViewport
-import no.strooped.GameSingleton
+import no.strooped.singleton.GameSingleton
 import no.strooped.StroopedController
-import no.strooped.TextureSizes
-import no.strooped.view.screen.components.Label
-import no.strooped.view.screen.components.PlacementLabel
-import no.strooped.view.screen.components.UIButton
+import no.strooped.singleton.TextureSizes
+import no.strooped.view.components.Label
+import no.strooped.view.components.PlacementLabel
+import no.strooped.view.components.UIButton
 
 /**
  * Uses https://otter.tech/an-mvc-guide-for-libgdx/ as inspiration

--- a/core/src/main/kotlin/no/strooped/view/screen/EndRoundScreen.kt
+++ b/core/src/main/kotlin/no/strooped/view/screen/EndRoundScreen.kt
@@ -7,8 +7,8 @@ import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.utils.viewport.ScreenViewport
-import no.strooped.singleton.GameSingleton
 import no.strooped.StroopedController
+import no.strooped.singleton.GameSingleton
 import no.strooped.singleton.TextureSizes
 import no.strooped.view.components.Label
 import no.strooped.view.components.PlacementLabel

--- a/core/src/main/kotlin/no/strooped/view/screen/JoinGameScreen.kt
+++ b/core/src/main/kotlin/no/strooped/view/screen/JoinGameScreen.kt
@@ -9,12 +9,19 @@ import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.utils.viewport.ScreenViewport
 import no.strooped.StroopedController
 import no.strooped.TextureSizes
+import no.strooped.model.GameRoom
+import no.strooped.view.screen.components.Label
 import no.strooped.view.screen.components.TextFieldInput
 import no.strooped.view.screen.components.UIButton
+
 /**
  * Uses https://otter.tech/an-mvc-guide-for-libgdx/ as inspiration
  * */
-class JoinGameScreen(private val controller: StroopedController) : Screen {
+class JoinGameScreen(
+    private val controller: StroopedController,
+    private val errorMessage: String? = null,
+    private val storedGame: GameRoom? = null
+) : Screen {
 
     var ui: Stage = Stage(ScreenViewport())
     private val backgroundPosition = Vector2(0f, 0f)
@@ -69,6 +76,12 @@ class JoinGameScreen(private val controller: StroopedController) : Screen {
 
         joinButton.onClick {
             controller.connectToGame(username = username.text, joinPin = pin.text)
+        }
+
+        errorMessage?.let {
+            println("Found error message $it")
+            val errorMessage = Label(it, Vector2(joinButtonPosition.x, joinButtonPosition.y + 75), 200f, 2f)
+            ui.addActor(errorMessage)
         }
     }
 

--- a/core/src/main/kotlin/no/strooped/view/screen/JoinGameScreen.kt
+++ b/core/src/main/kotlin/no/strooped/view/screen/JoinGameScreen.kt
@@ -8,19 +8,17 @@ import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.utils.viewport.ScreenViewport
 import no.strooped.StroopedController
-import no.strooped.TextureSizes
-import no.strooped.model.GameRoom
-import no.strooped.view.screen.components.Label
-import no.strooped.view.screen.components.TextFieldInput
-import no.strooped.view.screen.components.UIButton
+import no.strooped.singleton.TextureSizes
+import no.strooped.view.components.Label
+import no.strooped.view.components.TextFieldInput
+import no.strooped.view.components.UIButton
 
 /**
  * Uses https://otter.tech/an-mvc-guide-for-libgdx/ as inspiration
  * */
 class JoinGameScreen(
     private val controller: StroopedController,
-    private val errorMessage: String? = null,
-    private val storedGame: GameRoom? = null
+    private val errorMessage: String? = null
 ) : Screen {
 
     var ui: Stage = Stage(ScreenViewport())
@@ -35,6 +33,10 @@ class JoinGameScreen(
     )
     private val usernamePosition = Vector2(Gdx.graphics.width * 0.15f, Gdx.graphics.height * 0.56f)
     private val pinPosition = Vector2(Gdx.graphics.width * 0.15f, Gdx.graphics.height * 0.44f)
+    private val errorPosition = Vector2(
+        Gdx.graphics.width * 0.05f,
+        joinButtonPosition.y - 2 * TextureSizes.joinButton.height
+    )
     private val background: Image = Image(Texture("background.png"))
     private val logo: Image = Image(Texture("logo.png"))
     private val joinButton: UIButton = UIButton(
@@ -79,8 +81,7 @@ class JoinGameScreen(
         }
 
         errorMessage?.let {
-            println("Found error message $it")
-            val errorMessage = Label(it, Vector2(joinButtonPosition.x, joinButtonPosition.y + 75), 200f, 2f)
+            val errorMessage = Label(it, errorPosition, Gdx.graphics.width * 0.9f, TextureSizes.getScaledFontSize(2.0f))
             ui.addActor(errorMessage)
         }
     }

--- a/core/src/main/kotlin/no/strooped/view/screen/LobbyScreen.kt
+++ b/core/src/main/kotlin/no/strooped/view/screen/LobbyScreen.kt
@@ -10,10 +10,10 @@ import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.utils.viewport.ScreenViewport
 import no.strooped.StroopedController
-import no.strooped.TextureSizes
-import no.strooped.view.screen.components.Animation
-import no.strooped.view.screen.components.Label
-import no.strooped.view.screen.components.UIButton
+import no.strooped.singleton.TextureSizes
+import no.strooped.view.components.Animation
+import no.strooped.view.components.Label
+import no.strooped.view.components.UIButton
 /**
  * Uses https://otter.tech/an-mvc-guide-for-libgdx/ as inspiration
  * */

--- a/core/src/main/kotlin/no/strooped/view/screen/TaskScreen.kt
+++ b/core/src/main/kotlin/no/strooped/view/screen/TaskScreen.kt
@@ -8,11 +8,11 @@ import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.utils.viewport.ScreenViewport
-import no.strooped.singleton.GameSingleton
 import no.strooped.StroopedController
-import no.strooped.singleton.TextureSizes
-import no.strooped.model.Task
 import no.strooped.model.Answer
+import no.strooped.model.Task
+import no.strooped.singleton.GameSingleton
+import no.strooped.singleton.TextureSizes
 import no.strooped.view.components.Button
 import no.strooped.view.components.ColorButton
 import no.strooped.view.components.Label

--- a/core/src/main/kotlin/no/strooped/view/screen/TaskScreen.kt
+++ b/core/src/main/kotlin/no/strooped/view/screen/TaskScreen.kt
@@ -8,14 +8,14 @@ import com.badlogic.gdx.math.Vector2
 import com.badlogic.gdx.scenes.scene2d.Stage
 import com.badlogic.gdx.scenes.scene2d.ui.Image
 import com.badlogic.gdx.utils.viewport.ScreenViewport
-import no.strooped.GameSingleton
+import no.strooped.singleton.GameSingleton
 import no.strooped.StroopedController
-import no.strooped.TextureSizes
+import no.strooped.singleton.TextureSizes
 import no.strooped.model.Task
-import no.strooped.view.screen.components.Answer
-import no.strooped.view.screen.components.Button
-import no.strooped.view.screen.components.ColorButton
-import no.strooped.view.screen.components.Label
+import no.strooped.model.Answer
+import no.strooped.view.components.Button
+import no.strooped.view.components.ColorButton
+import no.strooped.view.components.Label
 /**
  * Uses https://otter.tech/an-mvc-guide-for-libgdx/ as inspiration
  * */


### PR DESCRIPTION
Do not merge this as it is now.

This PR demonstrates how to use Kotlin's [Result](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result/)-class to pass along success or failure cases when attempting to connect to the socket.

The idea is that onConnect events calls a function and passes it a result object, which will be success if we successfully connected or failure, if something went wrong